### PR TITLE
Trigger cohort sync on user-creation/user profile update

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Event observers used in auth mcae plugin.
+ * @copyright  2016 Dan Marsden
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+defined('MOODLE_INTERNAL') || die();
+
+class auth_mcae_observer {
+    /**
+     * Observer function to handle the user created event
+     * @param \core\event\user_created $event
+     */
+    public static function user_created(\core\event\user_created $event) {
+        global $CFG, $DB;
+        if (is_enabled_auth('mcae')) {
+            require_once($CFG->dirroot . '/auth/mcae/auth.php');
+            $eventdata = $event->get_data();
+            $auth = get_auth_plugin('mcae');
+            if ($user = $DB->get_record('user', array('id' => $eventdata['relateduserid']))) {
+                $auth->user_authenticated_hook($user, $user->username, '');
+            }
+        }
+    }
+
+    /**
+     * Observer function to handle the user updated event
+     * @param \core\event\user_created $event
+     */
+    public static function user_updated(\core\event\user_updated $event) {
+        global $CFG, $DB;
+        if (is_enabled_auth('mcae')) {
+            require_once($CFG->dirroot . '/auth/mcae/auth.php');
+            $eventdata = $event->get_data();
+            $auth = get_auth_plugin('mcae');
+            if ($user = $DB->get_record('user', array('id' => $eventdata['relateduserid']))) {
+                $auth->user_authenticated_hook($user, $user->username, '');
+            }
+        }
+    }
+
+}

--- a/cli/sync_users.php
+++ b/cli/sync_users.php
@@ -31,7 +31,7 @@ if (!is_enabled_auth('mcae')) {
 }
 
 $auth  = get_auth_plugin('mcae');
-$users = $DB->get_records('user', array('deleted' => 0));
+$users = $DB->get_recordset('user', array('deleted' => 0));
 
 echo "Start transaction.\n";
 $transaction = $DB->start_delegated_transaction();
@@ -42,6 +42,7 @@ foreach ($users as $user) {
     $auth->user_authenticated_hook($user, $username, '');
     echo "done.\n";
 }
+$users->close();
 
 $transaction->allow_commit();
 exit("\nFinish\n");

--- a/db/events.php
+++ b/db/events.php
@@ -14,17 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * @package    auth
- * @subpackage mcae
- * @copyright  2011 Andrew "Kama" (kamasutra12@yandex.ru)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version   = 2016022901;
-$plugin->component = 'auth_mcae';
-$plugin->maturity = MATURITY_STABLE;
-$plugin->requires = 2015102300;
-$plugin->release = '3.1';
+$observers = array (
+    array(
+        'eventname' => '\core\event\user_created',
+        'callback' => 'auth_mcae_observer::user_created'
+    ),
+    array(
+        'eventname' => '\core\event\user_updated',
+        'callback' => 'auth_mcae_observer::user_updated'
+    ));


### PR DESCRIPTION
Here's the start of some work I did to allow the sync to be triggered when a user updates their profile or a new user is created. Ideally this would also remove the user_authenticated_hook from being triggered as it will not be needed anymore and move the code from user_authenticated_hook into a generic function instead but I left it for now so that if you don't want to use this method I can maintain the local changes without too much change to the core code. Feel free to close this one if you don't want to change to using this method! - thanks!